### PR TITLE
[WIP] Add a database initialization/quick-ingest script to speed up testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,9 @@
 
 # Ignore any .ipynb checkpoint directories
 **/.ipynb_checkpoints
+
+# Ignore the generic name of the Synthea/CodeX breast cancer dataset downloadable here: https://confluence.hl7.org/display/COD/mCODE+Test+Data
+10yrs
+
+# Ignore OSX Desktop Services Store file
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -13,26 +13,47 @@ For the development of differentially private federated machine learning on the 
 2. **Spin up Katsu.** Run `docker-compose up katsu`
 3. **Browse Katsu.** Navigate your browser to `localhost:8000`
 
-## Ingesting Data
+## Ingest
 
 The `federated-learning` repository has provided a bash script interface for you to communicate with Katsu. To ingest data, into Katsu, you must first create a project, dataset, and table in Katsu for your data to live in. The bash interface makes this a chain of straightforward commands. The bash scripts assume your Katsu container is tagged `katsu`, as is the case if you have followed the quick start thus far.
 
-We have [walkthrough examples](#examples) to ingest files from our `mohccn-data` repository and the CodeX/Synthea breast cancer dataset.
-### Creating a Project
+See [Quick Ingest](#quick-ingest) below to quickly initialize the database for testing.
+
+We also provide [walkthrough examples](#examples) to manually ingest files from our `mohccn-data` repository and the CodeX/Synthea breast cancer dataset.
+
+### Quick Ingest
+
+`ingestion_scripts/init.sh` is provided to help you quickly initialize the Katsu database for ingestion, and optionally ingest straight into it.
+
+To create a Project, Dataset, and Table, and ingest a locally-stored directory straight into the generated table, run:
+```bash
+./ingestion_scripts/init.sh -l -d <PATH_TO_LOCAL_INGESTABLE_DIR> <PROJECT_TITLE> <DATASET_TITLE> <TABLE_TITLE> <TABLE_TYPE>
+```
+
+For example, the following command ingests all files in the local `synthea-examples` directory as `mcodepackets` into the `test_` project/dataset/table.
+```bash
+./ingestion_scripts/init.sh -l -d ./synthea-examples test_proj test_dataset test_table mcodepacket
+```
+
+Note that you can exclude the `-d`/`-f` options to simply intialize the database without actually running the ingestion, then run `./ingestion_scripts/ingest.sh` to do the ingest in a later step.
+
+### Manual Ingest
+
+#### Creating a Project
 To create a project, run
 ```bash
 bash ingestion_scripts/create_project.sh <PROJECT_TITLE>
 ```
 This should return a uuid that you should save to use in the next command to create a dataset. See `bash ingestion_scripts/create_project.sh -h` for details.
 
-### Creating a Dataset
+#### Creating a Dataset
 To create a dataset, run
 ```bash
 bash ingestion_scripts/create_dataset.sh <PROJECT_UUID> <DATASET_NAME>
 ```
 This should return a uuid that you should save to use in the next command to create a table. See `bash ingestion_scripts/create_dataset.sh -h` for details.
 
-### Creating a Table
+#### Creating a Table
 To create a table, run
 ```bash
 bash ingestion_scripts/create_table.sh <DATASET_UUID> <TABLE_NAME> <TABLE_TYPE>
@@ -40,7 +61,7 @@ bash ingestion_scripts/create_table.sh <DATASET_UUID> <TABLE_NAME> <TABLE_TYPE>
 where `<TABLE_TYPE>` is one of "mcodepacket" or "phenopacket", depending on the type of data you expect to ingest into the table.
 This should return a uuid that you should save to use in the next command to ingest data. See `bash ingestion_scripts/create_table.sh -h` for details.
 
-### Ingesting Data
+#### Ingesting Data
 To ingest data, use the `ingest.sh` script. Roughly speaking, the script runs as follows
 ```bash
 bash ingestion_scripts/ingest.sh <TABLE_UUID> <WORKFLOW_ID> <ABSOLUTE_PATH>
@@ -57,9 +78,9 @@ See `bash ingestion_scripts/ingest.sh -h` for more details.
 
 We have walkthrough examples of using the `ingest.sh` script to ingest both single files and directories in our examples section below.
 
-## Examples
+##### Examples
 
-### Ingesting Single Files
+###### Ingesting Single Files
 The `federated-learning` repository provides sample MCODE data in the `mohccn-data` submodule to ingest onto a local Katsu instance. To ingest this data, we first create a project by running
 ```bash
 bash ingestion_scripts/create_project.sh mohccn-test
@@ -81,7 +102,7 @@ After ingesting, you should see a message resembling the following
 mcodepacket Data have been ingested from source at /app/chord_metadata_service/scripts/mCode_ingest_scripts.json
 ```
 
-### Ingesting Directories
+###### Ingesting Directories
 The `federated-learning` repository uses the [CodeX/Synthea-1 2000 Female Breast Cancer Synthetic MCODE Dataset](https://confluence.hl7.org/display/COD/mCODE+Test+Data). Since this is currently a dead link as of writing, we provide a small sample of this data to ingest in the `synthea-examples` directory. To ingest this data, we first create a project by running
 ```bash
 bash ingestion_scripts/create_project.sh synthea-test

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ For the development of differentially private federated machine learning on the 
 1. **Configure docker-compose.** The `docker-compose.yaml` file expects a `.env` file in root folder, so that it can configure the Katsu database with some secrets such as the password. For a generic configuration, you can run the following to copy and use the default configuration: `cp .default.env .env`
 2. **Spin up Katsu.** Run `docker-compose up katsu`
 3. **Browse Katsu.** Navigate your browser to `localhost:8000`
+4. **Query Katsu** by GETting from `localhost:8000/api/mcodepackets`. There will be zero results (`"count": 0`) prior to ingest, and a number of results equal to the dataset size following ingest.
 
 ## Ingest
 
@@ -30,12 +31,25 @@ To create a Project, Dataset, and Table, and ingest a locally-stored directory s
 ./ingestion_scripts/init.sh -l -d <PATH_TO_LOCAL_INGESTABLE_DIR> <PROJECT_TITLE> <DATASET_TITLE> <TABLE_TITLE> <TABLE_TYPE>
 ```
 
-For example, the following command ingests all files in the local `synthea-examples` directory as `mcodepackets` into the `test_` project/dataset/table.
+Note that you can exclude the `-d`/`-f` options to simply intialize the database without actually running the ingestion, then run `./ingestion_scripts/ingest.sh` to do the ingest in a later step.
+
+#### Synthea/CodeX Synthetic Breast Cancer MCODE dataset
+
+The dataset currently being used for training can be browsed [here](https://confluence.hl7.org/display/COD/mCODE+Test+Data) under `Approx. 2,000 Patient Records with 10 Years of Medical History`. Or, just clicl this direct download [link](http://hdx.mitre.org/downloads/mcode/mcode1_0_10yrs.zip).
+
+Once downloaded, unzip the folder and move the `10yrs` subdirectory into the `federated-learning` project root, or wherever you prefer.
+
+The following command ingests all files in the local `10yrs/female` directory as `mcodepackets` into the `test_` project/dataset/table.
 ```bash
-./ingestion_scripts/init.sh -l -d ./synthea-examples test_proj test_dataset test_table mcodepacket
+./ingestion_scripts/init.sh -l -d 10yrs/female test_proj test_dataset test_table mcodepacket
 ```
 
-Note that you can exclude the `-d`/`-f` options to simply intialize the database without actually running the ingestion, then run `./ingestion_scripts/ingest.sh` to do the ingest in a later step.
+The EDA and model training files in this repository were done using only the data in the `female` subdirectory. If you wish to ingest all of the `female`, `male`, and `assorted` data together (thereby increasing the corpus size) simply move all of the files together into a single folder and ingest that folder:
+```bash
+cp 10yrs/female/* 10yrs/male/* 10yrs/assorted/* 10yrs
+rmdir 10yrs/female 10yrs/male 10yrs/assorted
+./ingestion_scripts/init.sh -l -d 10yrs test_proj test_dataset test_table mcodepacket
+```
 
 ### Manual Ingest
 

--- a/ingestion_scripts/ingest.sh
+++ b/ingestion_scripts/ingest.sh
@@ -82,7 +82,7 @@ absolute_path="$3"
 if [ "$LOCAL" = true ] ; then
   echo "local flag specified. Copying path into Docker container."
   basename="$(basename $absolute_path)"
-  docker cp $absolute_path katsu:$KATSU_INGESTION_DIR$basename
+  docker cp $absolute_path katsu:$KATSU_INGESTION_DIR
   absolute_path="$KATSU_INGESTION_DIR$basename" # now absolute_path must be either the user provided Docker path or the script created one.
   echo $absolute_path
 fi

--- a/ingestion_scripts/init.sh
+++ b/ingestion_scripts/init.sh
@@ -16,7 +16,7 @@ help ()
    echo "Optionally runs ingest.sh on a specified file or directory."
    echo
    echo "Usage:"
-   echo "   ./init.sh [options] PROJECT_TITLE DATASET_TITLE TABLE_TITLE TABLE_TYPE"
+   echo "   ./ingestion_scripts/init.sh [options] PROJECT_TITLE DATASET_TITLE TABLE_TITLE TABLE_TYPE"
    echo "Arguments:"
    echo "   PROJECT_TITLE   The title of the newly created project."
    echo "   DATASET_TITLE   The title of the newly created dataset."
@@ -72,7 +72,7 @@ while getopts ":hd:f:s:" opt; do
 done
 shift $((OPTIND - 1))
 
-if [ $# -lt 3 ]; 
+if [ $# -lt 4 ]; 
    then 
    printf "Not enough arguments - %d. Call the script with the -h flag for details.\n" $# 
    exit 0 
@@ -109,6 +109,7 @@ echo
 echo "TABLE_UUID: " $TABLE_UUID
 echo
 
+# TODO add support for ingest.sh's -l option; ingest on or off the container/host
 # If script was run with either of the ingest options, run ingest.sh on the specified file(s)
 if [ ! -z "${ingest_filepath}" ]; then
     bash ingestion_scripts/ingest.sh -l $TABLE_UUID mcode_json ingest_filepath

--- a/ingestion_scripts/init.sh
+++ b/ingestion_scripts/init.sh
@@ -1,0 +1,117 @@
+#!/bin/bash 
+################################################################################
+# Constants                                                                    #
+################################################################################
+SERVER_URL="http://localhost:8000"
+
+################################################################################
+# Help                                                                         #
+################################################################################
+help ()
+{
+   # Display Help
+   echo
+   echo "NOTE: OPTIONS MUST PRECEDE ALL ARGUMENTS"
+   echo "Creates a project, dataset, and table in Katsu for ingesting into."
+   echo "Optionally runs ingest.sh on a specified file or directory."
+   echo
+   echo "Usage:"
+   echo "   ./init.sh [options] PROJECT_TITLE DATASET_TITLE TABLE_TITLE TABLE_TYPE"
+   echo "Arguments:"
+   echo "   PROJECT_TITLE   The title of the newly created project."
+   echo "   DATASET_TITLE   The title of the newly created dataset."
+   echo "   TABLE_TITLE     The title of the newly created table."
+   echo "   TABLE_TYPE      The type of the newly created table."
+   echo "                   Options are [\"phenopacket\" or \"mcodepacket\"]."
+   echo "Options:"
+   echo "   -h      Display this help text"
+   echo "   -d      Run ingest.sh on the specified directory after initialization"
+   echo "   -f      Run ingest.sh on the specified file after intitialization"
+   echo "   -s      Use this flag if you have a custom server url (default is http://localhost:8000)"
+}
+################################################################################
+################################################################################
+# Main program                                                                 #
+################################################################################
+################################################################################
+
+# Creates a project in Katsu
+# Outputs the UUID of the created project
+_create_project () {
+    docker exec -it katsu python /app/chord_metadata_service/ingestion_scripts/create_proj.py $proj_title $SERVER_URL
+}
+
+# Creates a dataset in Katsu
+# Outputs the UUID of the created dataset
+_create_dset () {
+    docker exec -it katsu python /app/chord_metadata_service/ingestion_scripts/create_dset.py $PROJ_UUID $dset_title $SERVER_URL
+}
+# Creates a dataset in Katsu
+# Outputs the UUID of the created table
+_create_table () {
+    docker exec -it katsu python /app/chord_metadata_service/ingestion_scripts/create_table.py $DSET_UUID $table_title $table_type $SERVER_URL
+}
+
+################################# Script start
+
+# Read in the script options
+while getopts ":hd:f:s:" opt; do
+  case $opt in
+    h)  help
+        exit
+        ;;
+    d)  ingest_dirpath=$OPTARG
+        ;;
+    f)  ingest_filepath=$OPTARG
+        ;;
+    s)  SERVER_URL=$OPTARG
+        ;;
+    \?) echo "Invalid option -$OPTARG" >&2
+        ;;
+  esac
+done
+shift $((OPTIND - 1))
+
+if [ $# -lt 3 ]; 
+   then 
+   printf "Not enough arguments - %d. Call the script with the -h flag for details.\n" $# 
+   exit 0 
+fi 
+
+# Read in the script arguments
+proj_title="$1"
+dset_title="$2"
+table_title="$3"
+table_type="$4"
+
+# TODO remove
+echo "proj_title: " $proj_title
+echo "dset_title: "$dset_title
+echo "table_title: "$table_title
+echo "table_type: "$table_type
+
+# Run the initializing script
+echo "Creating the project..."
+export PROJ_UUID=$(_create_project)
+echo
+echo "PROJ_UUID: " $PROJ_UUID
+echo
+
+echo "Creating the dataset..."
+export DSET_UUID=$(_create_dset)
+echo
+echo "DSET_UUID: " $DSET_UUID
+echo
+
+echo "Creating the table..."
+export TABLE_UUID=$(_create_table)
+echo
+echo "TABLE_UUID: " $TABLE_UUID
+echo
+
+# If script was run with either of the ingest options, run ingest.sh on the specified file(s)
+if [ ! -z "${ingest_filepath}" ]; then
+    bash ingestion_scripts/ingest.sh -l $TABLE_UUID mcode_json ingest_filepath
+elif [ ! -z "${ingest_dirpath}" ]; then
+    bash ingestion_scripts/ingest.sh -l -d $TABLE_UUID mcode_fhir_json ingest_dirpath
+fi

--- a/ingestion_scripts/internal/create_dset.py
+++ b/ingestion_scripts/internal/create_dset.py
@@ -35,6 +35,7 @@ def create_dataset(katsu_server_url: str, project_uuid: str, dataset_title: str)
         print(
             "Something else went wrong. It might be that your a table with the same name already exists or that your table name is too short."
         )
+        print(r2.json())
         sys.exit()
     else:
         print(r2.json())
@@ -52,9 +53,9 @@ def main():
   parser.add_argument("server_url", help="The URL of Katsu Instance.")
 
   args = parser.parse_args()
-  project_uuid = args.project_uuid
-  dataset_name = args.dataset_name
-  katsu_server_url = args.server_url
+  project_uuid = str.strip(args.project_uuid)
+  dataset_name = str.strip(args.dataset_name)
+  katsu_server_url = str.strip(args.server_url)
 
   dataset_uuid = create_dataset(katsu_server_url, project_uuid, dataset_name)
   print(dataset_uuid)

--- a/ingestion_scripts/internal/create_proj.py
+++ b/ingestion_scripts/internal/create_proj.py
@@ -52,8 +52,8 @@ def main():
   parser.add_argument("server_url", help="The URL of Katsu Instance.")
 
   args = parser.parse_args()
-  project_name = args.project_name
-  katsu_server_url = args.server_url
+  project_name = str.strip(args.project_name)
+  katsu_server_url = str.strip(args.server_url)
 
   project_uuid = create_project(katsu_server_url, project_name)
   print(project_uuid)

--- a/ingestion_scripts/internal/create_table.py
+++ b/ingestion_scripts/internal/create_table.py
@@ -42,10 +42,10 @@ def main():
   parser.add_argument("server_url", help="The URL of Katsu Instance.")
 
   args = parser.parse_args()
-  dataset_uuid = args.dataset_uuid
-  table_name = args.table
-  katsu_server_url = args.server_url
-  data_type = args.data_type
+  dataset_uuid = str.strip(args.dataset_uuid)
+  table_name = str.strip(args.table)
+  katsu_server_url = str.strip(args.server_url)
+  data_type = str.strip(args.data_type)
 
   if data_type not in ['phenopacket', 'mcodepacket']:
       print("Table data type must be either phenopacket or mcodepacket.")

--- a/ingestion_scripts/internal/ingest_file.py
+++ b/ingestion_scripts/internal/ingest_file.py
@@ -75,10 +75,10 @@ def main():
   parser.add_argument("workflow", help="The ingest workflow. Only phenopackets_json, mcode_json, and mcode_fhir_json are supported.")
   
   args = parser.parse_args()
-  table_uuid = args.table_uuid
-  katsu_server_url = args.server_url
-  data_file = args.data_path
-  workflow = args.workflow
+  table_uuid = str.strip(args.table_uuid)
+  katsu_server_url = str.strip(args.server_url)
+  data_file = str.strip(args.data_path)
+  workflow = str.strip(args.workflow)
 
   # Piping from 'ls' in the bash script creates ANSI escape sequences that need to be filtered
   ansi_escape = re.compile(r'''


### PR DESCRIPTION
This PR improves the Katsu ingest interface provided by this repository by adding the `init.sh` script, which automatically initializes a project, dataset, and table in the Katsu database in preparation for ingest, and optionally ingests data into the resulting table.

## Changelog
- Adds `init.sh` script for quickly initializing the Katsu database, and optionally running the ingest immediately thereafter.
- Documents usage of the `init.sh` script
- Slightly reorganizes the `Ingest` section of the README
- Improves argument parsing by the ingest `.py` files, in order to better interoperate with bash scripts